### PR TITLE
impressionsテーブルにindexを貼る

### DIFF
--- a/db/migrate/20181107154209_add_index_to_impressions.rb
+++ b/db/migrate/20181107154209_add_index_to_impressions.rb
@@ -1,0 +1,16 @@
+class AddIndexToImpressions < ActiveRecord::Migration[5.2]
+  def up
+    # indexの貼り方
+    # add_index table名, カラム名
+    # add_index table名, [カラム名, カラム名], :name => '複合index名'
+    add_index :impressions, [:user_id, :book_id], :name => 'user_book_id', :unique => true
+    add_index :impressions, :user_id
+    add_index :impressions, :book_id
+  end
+
+  def down      
+    remove_index :impressions, :name => 'user_book_id'
+    remove_index :impressions, :user_id
+    remove_index :impressions, :book_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_06_102855) do
+ActiveRecord::Schema.define(version: 2018_11_07_154209) do
 
   create_table "bookstores", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
@@ -39,6 +39,9 @@ ActiveRecord::Schema.define(version: 2018_11_06_102855) do
     t.integer "book_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["book_id"], name: "index_impressions_on_book_id"
+    t.index ["user_id", "book_id"], name: "user_book_id", unique: true
+    t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
## indexについて
migrationファイルを参考にしてください。up / downの両方が必要な点に注意してください。
複合indexを作成すると、下記のようにKey部分にMUL（Multi）が付きます
```
mysql> desc impressions;
+-------------+------------+------+-----+---------+----------------+
| Field       | Type       | Null | Key | Default | Extra          |
+-------------+------------+------+-----+---------+----------------+
| id          | bigint(20) | NO   | PRI | NULL    | auto_increment |
| story       | text       | YES  |     | NULL    |                |
| impressions | text       | YES  |     | NULL    |                |
| user_id     | int(11)    | YES  | MUL | NULL    |                |
| book_id     | int(11)    | YES  | MUL | NULL    |                |
| created_at  | datetime   | NO   |     | NULL    |                |
| updated_at  | datetime   | NO   |     | NULL    |                |
+-------------+------------+------+-----+---------+----------------+
7 rows in set (0.00 sec)
```